### PR TITLE
Option to shorten names in graph, and a couple of smaller improvements

### DIFF
--- a/data/blacklist.txt
+++ b/data/blacklist.txt
@@ -2,8 +2,12 @@ malloc free realloc
 fwrite vfprintf
 access
 pthread_mutex_lock
+std::mutex::lock
+std::condition_variable::wait
 getcwd
 open
 _ZNSo5flushEv
+_ZdlPv
 _ZdaPv
+_Znwm
 _Znaj

--- a/data/whitelist.txt
+++ b/data/whitelist.txt
@@ -21,6 +21,7 @@ jack_get_buffer_size
 jack_midi_event_write
 jack_ringbuffer_peek
 jack_last_frame_time
+jack_midi_max_event_size
 
 std::__throw_bad_function_call
 std::__throw_bad_alloc
@@ -45,6 +46,7 @@ _ZNKSs5c_strEv
 _ZNKSs6lengthEv
 
 ceil
+ceilf
 rint
 isnan
 
@@ -64,6 +66,8 @@ atanf
 sqrt
 log10
 log10f
+log2
+log2f
 floor
 floorf
 sqrtf
@@ -74,6 +78,7 @@ round
 roundf
 carg
 asinf
+copysign
 errx
 warnx
 __fmod_finite

--- a/stoat
+++ b/stoat
@@ -796,7 +796,7 @@ if options.graphfile
     node_list = Hash.new
     color_nodes.each do |key,val|
         if(demangled_short.include?(key) && demangled_short[key] && demangled_short[key].length != 0 && important_nodes.include?(key))
-            node_list[key] = g.add_nodes(demangled_short[key], "color"=> val)
+            node_list[key] = g.add_nodes(demangled_short[key], "color"=> val, :shape=>:box)
         end
     end
 

--- a/stoat
+++ b/stoat
@@ -811,7 +811,7 @@ if options.graphfile
                                     (?: (?> [^<>]+ ) | \g<args>)*
                                  > ) /x, '<>')
                 # remove return type
-                name = name.sub(/^(?!operator).* /, '')
+                name = name.sub(/^(?!operator).* (?=[^<])/, '')
                 # remove leading namespaces (keep the last two components of the name)
                 name = name.sub(/(\w+(<>)?::)*(\w+(<>)?::)/, '\3')
                 # insert line breaks

--- a/stoat
+++ b/stoat
@@ -357,7 +357,7 @@ demangled_symbols = Hash.new
 demangled_short   = Hash.new
 
 #Generate a shortened demangled name by removing the function arguments
-def shorten_symbol(sym_)
+def remove_arguments(sym_)
     return sym_ if sym_ =~ /\$vtable\d+$/
 
     paren = 0
@@ -381,6 +381,24 @@ def shorten_symbol(sym_)
     sym.reverse
 end
 
+def shorten_name(name)
+    # replace template arguments
+    name = name.gsub(/ (?<args> <
+                        (?: (?> [^<>]+ ) | \g<args>)*
+                     > ) /x, '<>')
+    # remove return type
+    name = name.sub(/^(?!operator).* (?=[^<])/, '')
+    # remove leading namespaces (keep the last two components of the name)
+    name = name.sub(/(\w+(<>)?::)*(\w+(<>)?::)/, '\3')
+    # insert line breaks
+    if(name =~ /^_Z\w{20,}_$/)
+        name = name.chars.each_slice(20).map(&:join).join("\n")
+    else
+        name = name.gsub('::', "::\n")
+    end
+    name
+end
+
 #Translate from mangled symbols into a list of demangled items
 def demangle(symbol_list, demangled_symbols, demangled_short, rtosc)
     $stderr.puts "Demangling #{symbol_list.length} Symbols..."
@@ -397,7 +415,7 @@ def demangle(symbol_list, demangled_symbols, demangled_short, rtosc)
     end
 
     demangled_symbols.each do |key, value|
-        m = shorten_symbol(value)
+        m = remove_arguments(value)
         if(m.empty?)
             demangled_short[key] = value
         else
@@ -806,20 +824,7 @@ if options.graphfile
         if(demangled_short.include?(key) && demangled_short[key] && demangled_short[key].length != 0 && important_nodes.include?(key))
             name = demangled_short[key]
             if(options.shorten)
-                # replace template arguments
-                name = name.gsub(/ (?<args> <
-                                    (?: (?> [^<>]+ ) | \g<args>)*
-                                 > ) /x, '<>')
-                # remove return type
-                name = name.sub(/^(?!operator).* (?=[^<])/, '')
-                # remove leading namespaces (keep the last two components of the name)
-                name = name.sub(/(\w+(<>)?::)*(\w+(<>)?::)/, '\3')
-                # insert line breaks
-                if(name =~ /^_Z\w{20,}_$/)
-                    name = name.chars.each_slice(20).map(&:join).join("\n")
-                else
-                    name = name.gsub('::', "::\n")
-                end
+                name = shorten_name(name)
             end
             node_list[key] = g.add_nodes(name, "color"=> val, :shape=>:box)
         end

--- a/stoat
+++ b/stoat
@@ -63,10 +63,11 @@ options.graphfile = nil
 options.recursive = false
 options.dump_file = nil
 options.minimal_graph = false
+options.shorten = false
 options.colorize = false
 
 OptionParser.new do |opts|
-      opts.banner = "Usage: example.rb [options] FILES"
+      opts.banner = "Usage: stoat [options] FILES"
 
       opts.on("-w", "--whitelist FILE",
               "Define a Whitelist File") do |list|
@@ -103,6 +104,11 @@ OptionParser.new do |opts|
               "The Minimal Graph View Output File Name") do |file|
           options.graphfile = file
           options.minimal_graph = true
+      end
+
+      opts.on("-S", "--shorten-names",
+              "Omit Namespaces and Template Arguments in Graph") do
+          options.shorten = true
       end
 
       opts.on("-d", "--dump FILE.yaml",
@@ -798,7 +804,24 @@ if options.graphfile
     node_list = Hash.new
     color_nodes.each do |key,val|
         if(demangled_short.include?(key) && demangled_short[key] && demangled_short[key].length != 0 && important_nodes.include?(key))
-            node_list[key] = g.add_nodes(demangled_short[key], "color"=> val, :shape=>:box)
+            name = demangled_short[key]
+            if(options.shorten)
+                # replace template arguments
+                name = name.gsub(/ (?<args> <
+                                    (?: (?> [^<>]+ ) | \g<args>)*
+                                 > ) /x, '<>')
+                # remove return type
+                name = name.sub(/^(?!operator).* /, '')
+                # remove leading namespaces (keep the last two components of the name)
+                name = name.sub(/(\w+(<>)?::)*(\w+(<>)?::)/, '\3')
+                # insert line breaks
+                if(name =~ /^_Z\w{20,}_$/)
+                    name = name.chars.each_slice(20).map(&:join).join("\n")
+                else
+                    name = name.gsub('::', "::\n")
+                end
+            end
+            node_list[key] = g.add_nodes(name, "color"=> val, :shape=>:box)
         end
     end
 

--- a/stoat
+++ b/stoat
@@ -352,6 +352,8 @@ demangled_short   = Hash.new
 
 #Generate a shortened demangled name by removing the function arguments
 def shorten_symbol(sym_)
+    return sym_ if sym_ =~ /\$vtable\d+$/
+
     paren = 0
     finished = false
 

--- a/stoat-compile
+++ b/stoat-compile
@@ -21,7 +21,7 @@
 
 #Pretend to be clang
 NARGV = ARGV.collect {|x| x.gsub(/(?=\W)/, '\\')}
-puts `clang #{NARGV.join(' ')}`
+print `clang #{NARGV.join(' ')}`
 err_code = $?.to_i
 if(err_code != 0)
     exit(false)

--- a/stoat-compile++
+++ b/stoat-compile++
@@ -21,7 +21,7 @@
 
 #Pretend to be clang
 NARGV = ARGV.collect {|x| x.gsub(/(?=\W)/, '\\')}
-puts `clang++ #{NARGV.join(' ')}`
+print `clang++ #{NARGV.join(' ')}`
 err_code = $?.to_i
 if(err_code != 0)
     exit(false)


### PR DESCRIPTION
Removing template arguments from the names used in the graph also conflates different instantiations of the same class template (and creates multiple edges between these nodes). I tend to think of this as a feature rather than a bug.

Same project before...:
![callgraph](https://cloud.githubusercontent.com/assets/1679309/6825588/e2f7cfb4-d2fb-11e4-82ba-17e1347fb270.png)
...and with -S option:
![callgraph_short](https://cloud.githubusercontent.com/assets/1679309/6825596/efca9762-d2fb-11e4-87a9-bff12bb70026.png)