### PR TITLE
Fix dangling pointer in ExtractVtables; some minor updates

### DIFF
--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -8,7 +8,8 @@
 # LLVM_INSTALL_PREFIX   - Installation location of llvm
 
 find_program(LLVM_CONFIG
-    NAMES llvm-config-33 llvm-config-3.3 llvm-config-35 llvm-config-3.5 llvm-config-34 llvm-config-3.4 llvm-config
+    NAMES llvm-config llvm-config-37 llvm-config-3.7 llvm-config-36 llvm-config-3.6
+          llvm-config-35 llvm-config-3.5 llvm-config-34 llvm-config-3.4 llvm-config-33 llvm-config-3.3
     PATHS /usr/bin /usr/local/bin 
     DOC "llvm-config Configuration Helper")
 if(LLVM_CONFIG STREQUAL "LLVM_CONFIG-NOTFOUND")

--- a/data/whitelist.txt
+++ b/data/whitelist.txt
@@ -2,6 +2,8 @@ cos cosl cosf
 sin sinl sinf
 tan tanl tanf
 abs fabs fabsf fabsl cabs
+fmin fminf fminl
+fmax fmaxf fmaxl
 exp exp2f expf expl
 pow powf powl
 fmod fmodf fmodl
@@ -22,6 +24,7 @@ jack_midi_event_write
 jack_ringbuffer_peek
 jack_last_frame_time
 jack_midi_max_event_size
+jack_client_thread_id
 
 std::__throw_bad_function_call
 std::__throw_bad_alloc
@@ -59,17 +62,14 @@ strstr
 memmove
 strncpy
 sinh
-log
-logf
+log logf logl
+log10 log10f log10l
+log2 log2f log2l
 asinh
 atan
 atanh
 atanf
 sqrt
-log10
-log10f
-log2
-log2f
 floor
 floorf
 sqrtf
@@ -77,11 +77,12 @@ lrintf
 rintf
 llrint
 nearbyintf
-round
-roundf
+round roundf roundl
+trunc truncf truncl
+modf modff modfl
 carg
 asinf
-copysign
+copysign copysignf copysignl
 errx
 warnx
 cexp
@@ -156,6 +157,12 @@ strchr
 __log2_finite
 __divdc3
 __mulsc3
+
+_ZNSt6chrono3_V212system_clock3nowEv
+_ZNSt3__16chrono12steady_clock3nowEv
+
+_ZNSt18condition_variable10notify_allEv
+_ZNSt18condition_variable10notify_oneEv
 
 # hacks here
 struct.rtosc::RtData0

--- a/src/llvm-passes.cpp
+++ b/src/llvm-passes.cpp
@@ -591,7 +591,8 @@ struct ExtractVtables : public ModulePass {
         auto &gl = m.getGlobalList();
         for(auto &g:gl) {
             if(g.getName().str().substr(0,4) == "_ZTV") {
-                const char *vtable_name = g.getName().str().c_str();
+                std::string name(g.getName().str());
+                const char *vtable_name = name.c_str();
                 int status = 0;
                 char *realname = abi::__cxa_demangle(vtable_name, 0, 0, &status);
                 if(!realname || strstr(realname, "__cxxabi"))

--- a/stoat
+++ b/stoat
@@ -237,9 +237,10 @@ end
 
 #Identify opt binary name
 opt = nil
-["opt-3.3", "opt-3.4", "opt-3.5", "opt"].each do|x|
+["opt", "opt-3-7", "opt-3.6", "opt-3.5", "opt-3.4", "opt-3.3"].each do|x|
     if(!`which #{x} 2> /dev/null`.empty?)
         opt = x
+        break
     end
 end
 


### PR DESCRIPTION
Hi Mark,

Here's a fix for a memory corruption bug that was surprisingly difficult to actually trigger (I could only reproduce it with one particular function in one project).

I also updated the LLVM detection for recent versions, hopefully also mitigating issues when multiple versions are installed.

Dominic