### PR TITLE
Add DISABLE_LDCONFIG CMake flag to disable running ldconfig on install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ if(NOT RUBY OR NOT CLANG OR NOT CLANGPP)
     message(error_fatal "Missing Dependencies...")
 endif()
 
+set(DISABLE_LDCONFIG FALSE)
+
 link_directories(${LLVM_LIB_DIR})
 include_directories(${LLVM_INCLUDE_DIRS})
 
@@ -35,7 +37,10 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/lib/callgraph.rb
     DESTINATION share/stoat)
 install(FILES ${CMAKE_SOURCE_DIR}/data/whitelist.txt
               ${CMAKE_SOURCE_DIR}/data/blacklist.txt DESTINATION share/stoat)
-install(SCRIPT cmake/InstallScript.cmake)
+if (NOT ${DISABLE_LDCONFIG})
+    install(SCRIPT cmake/InstallScript.cmake)
+endif()
+
 
 ######################################################################
 #               Tests to verify it works                             #


### PR DESCRIPTION
Fixes #29 

I added a variable (`DISABLE_LDCONFIG`) to disable the ldconfig run because determining if a file is writable at build/install time didn't work and also didn't feel right because [dynamic configuration reduces the user's control](https://devmanual.gentoo.org/ebuild-writing/functions/src_configure/configuring/index.html) on the build's result.