### PR TITLE
Add missing header for llvm v9

### DIFF
--- a/src/llvm-passes.cpp
+++ b/src/llvm-passes.cpp
@@ -20,6 +20,7 @@
 
 #include <llvm/Analysis/CallGraph.h>
 #include <llvm/Support/raw_ostream.h>
+#include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/LLVMContext.h>


### PR DESCRIPTION
It won't compile without this anymore.