### PR TITLE
fix usage of deprecated getCalledValue => getCalledOperand

### DIFF
--- a/src/llvm-passes.cpp
+++ b/src/llvm-passes.cpp
@@ -161,7 +161,7 @@ struct ExtractCallGraph : public FunctionPass {
     std::string runOnCallInst(CallInst *call, Function &Fn)
     {
         auto fn2  = call->getCalledFunction();
-        auto it   = call->getCalledValue();
+        auto it   = call->getCalledOperand();
         auto it2  = dyn_cast<GlobalAlias>(it);
         auto load = dyn_cast<LoadInst>(it);
         string vtable_call_name = "";


### PR DESCRIPTION
was failing to build on arch linux until I changed this

https://reviews.llvm.org/D78882